### PR TITLE
fix light init type error

### DIFF
--- a/custom_components/sengledapi/light.py
+++ b/custom_components/sengledapi/light.py
@@ -138,7 +138,7 @@ class SengledBulb(LightEntity):
     @property
     def supported_features(self):
         """Flags Supported Features"""
-        features = ""
+        features = 0
         if self._support_brightness:
             features = SUPPORT_BRIGHTNESS
         if self._support_color_temp and self._support_brightness:


### PR DESCRIPTION
Fix TypeError #58 in light init.

Not sure if this is only being caused in newer versions of HA. I saw it v2022.2 in a docker container.