### PR TITLE
Fixes https://github.com/jfarmer08/ha-sengledapi/issues/71

### DIFF
--- a/custom_components/sengledapi/sengledapi/devices/bulbs/bulb.py
+++ b/custom_components/sengledapi/sengledapi/devices/bulbs/bulb.py
@@ -310,7 +310,7 @@ class Bulb:
                 + " updating."
             )
             if self._just_changed_state:
-                # self._just_changed_state = False
+                self._just_changed_state = False
                 _LOGGER.info(
                     "SengledApi: Bulb State Change: %s", self._just_changed_state
                 )


### PR DESCRIPTION
The previous logic would have caused _just_changed_state to never be set to False and thus the URL was never fired unless the object was re-created