### PR TITLE
Update supported_features and  add supported_color_modes to use new colormodes while maintaining  backward compatibility.

### DIFF
--- a/custom_components/sengledapi/light.py
+++ b/custom_components/sengledapi/light.py
@@ -151,7 +151,7 @@ class SengledBulb(LightEntity):
         return self._state
 
     @property
-    def supported_features(self):
+    def supported_color_modes(self):
         """Flags Supported Features"""
         features = 0
         if self._support_brightness:

--- a/custom_components/sengledapi/light.py
+++ b/custom_components/sengledapi/light.py
@@ -11,6 +11,9 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
     PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR_TEMP,
+    SUPPORT_COLOR,
     LightEntity,
     ColorMode,
 )
@@ -151,22 +154,33 @@ class SengledBulb(LightEntity):
         return self._state
 
     @property
-    def supported_color_modes(self):
+    def supported_features(self):
         """Flags Supported Features"""
         features = 0
         if self._support_brightness:
-            features = ColorMode.BRIGHTNESS
-        if self._support_color_temp and self._support_brightness:
-            features = ColorMode.BRIGHTNESS | ColorMode.COLOR_TEMP
-        if (
-            self._support_brightness
-            and self._support_color_temp
-            and self._support_color
-        ):
-            features = ColorMode.BRIGHTNESS | ColorMode.COLOR_TEMP | ColorMode.HS
+            features = SUPPORT_BRIGHTNESS
+        if self._support_color_temp:
+            features = features | SUPPORT_COLOR_TEMP
+        if self._support_color:
+            features = features | SUPPORT_COLOR
+        _LOGGER.debug("supported_features: %s", features)
+        return features
+
+    @property
+    def supported_color_modes(self):
+        """Flags Supported Features"""
+        features = set()
+        if self._support_brightness:
+            features.add(ColorMode.BRIGHTNESS)
+        if self._support_color_temp:
+            features.add(ColorMode.COLOR_TEMP)
+        if self._support_color:
+            features.add(ColorMode.HS)
+        _LOGGER.debug("supported_color_modes: %s", features)
         return features
 
     async def async_turn_on(self, **kwargs):
+        _LOGGER.debug("turn_on kwargs: %s", kwargs)
         """Turn on or control the light."""
         if (
             ATTR_BRIGHTNESS not in kwargs


### PR DESCRIPTION
Currently the supported_features function returns a ColorMode enum where HA expects binary flags. This was added here https://github.com/jfarmer08/ha-sengledapi/commit/fa42052d375294dfa558b51e846df15a57c554cb

I made this pull request after encountering the same issue as @ryanwaldron in issue #81 

After reading the docs here: https://developers.home-assistant.io/docs/core/entity/light/

Implementing supported_features as binary flags and adding supported_color_modes to return the corresponding set of  ColorMode enums is working for me.

