### PR TITLE
Fix Home Assistant 2025.3+ compatibility issues

### DIFF
--- a/custom_components/sengledapi/light.py
+++ b/custom_components/sengledapi/light.py
@@ -10,6 +10,8 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
+    DEFAULT_MAX_KELVIN,
+    DEFAULT_MIN_KELVIN,
     PLATFORM_SCHEMA,
     ColorMode,
     LightEntity,
@@ -108,13 +110,23 @@ class SengledBulb(LightEntity):
         return attributes
 
     @property
-    def color_temp(self):
-        """Return the color_temp of the light."""
-        _LOGGER.debug("Light.py color_temp %s", self._color_temperature)
+    def color_temp_kelvin(self):
+        """Return the color temperature in Kelvin."""
+        _LOGGER.debug("Light.py color_temp_kelvin %s", self._color_temperature)
         if self._color_temperature is None:
-            return colorutil.color_temperature_kelvin_to_mired(2000)
+            return 2000
         else:
-            return colorutil.color_temperature_kelvin_to_mired(self._color_temperature)
+            return self._color_temperature
+    
+    @property
+    def min_color_temp_kelvin(self):
+        """Return the minimum color temperature in Kelvin."""
+        return DEFAULT_MIN_KELVIN
+    
+    @property
+    def max_color_temp_kelvin(self):
+        """Return the maximum color temperature in Kelvin."""
+        return DEFAULT_MAX_KELVIN
 
     @property
     def hs_color(self):
@@ -143,21 +155,15 @@ class SengledBulb(LightEntity):
     @property
     def supported_color_modes(self):
         """Return the supported color modes for the light."""
-        color_modes = set()
-        
-        # Add all supported modes
+        # A light entity can only support one primary color mode.
+        # The priorities should be: HS > COLOR_TEMP > BRIGHTNESS > ONOFF
         if self._support_color:
-            color_modes.add(ColorMode.HS)
-        if self._support_color_temp:
-            color_modes.add(ColorMode.COLOR_TEMP)
-        if self._support_brightness:
-            color_modes.add(ColorMode.BRIGHTNESS)
-            
-        # If no specific modes are supported, add ONOFF mode
-        if not color_modes:
-            color_modes.add(ColorMode.ONOFF)
-            
-        return color_modes
+            return {ColorMode.HS}
+        elif self._support_color_temp:
+            return {ColorMode.COLOR_TEMP}
+        elif self._support_brightness:
+            return {ColorMode.BRIGHTNESS}
+        return {ColorMode.ONOFF}
 
     @property
     def color_mode(self):

--- a/custom_components/sengledapi/light.py
+++ b/custom_components/sengledapi/light.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 # Import the device class from the component that you want to support
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     PLATFORM_SCHEMA,
     ColorMode,
@@ -176,7 +176,7 @@ class SengledBulb(LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn on or control the light."""
         if not any(
-            key in kwargs for key in (ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_COLOR_TEMP)
+            key in kwargs for key in (ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_COLOR_TEMP_KELVIN)
         ):
             await self._light.async_toggle(ON)
         if ATTR_BRIGHTNESS in kwargs:
@@ -185,10 +185,8 @@ class SengledBulb(LightEntity):
             hs = kwargs.get(ATTR_HS_COLOR)
             color = colorutil.color_hs_to_RGB(hs[0], hs[1])
             await self._light.async_set_color(color)
-        if ATTR_COLOR_TEMP in kwargs:
-            color_temp = colorutil.color_temperature_mired_to_kelvin(
-                kwargs[ATTR_COLOR_TEMP]
-            )
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            color_temp = kwargs[ATTR_COLOR_TEMP_KELVIN]
             await self._light.async_color_temperature(color_temp)
 
     async def async_turn_off(self, **kwargs):


### PR DESCRIPTION
 ## Summary
  - Replace deprecated ATTR_COLOR_TEMP with ATTR_COLOR_TEMP_KELVIN to address upcoming deprecation warning
  - Update light entity to properly define color modes according to Home Assistant Core 2025.3+ requirements
  - Fix blocking call in MQTT client by moving SSL context creation to a separate thread
  - Add default brightness for brightness-capable bulbs
  - Improve color mode detection logic to represent the current state correctly

  ## Test plan
  - Verify lights connect and function properly in Home Assistant, paying attention to color and brightness
  - Confirm warning messages about deprecated constants and invalid color modes are resolved
  - Check that no blocking call warnings appear in the logs